### PR TITLE
Fixed xhtml structure, in-middle choice of types

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -42,7 +42,6 @@
         }
     },
     "linter": {
-        "ignore": ["test/**/*"],
         "rules": {
             "a11y": {
                 "noAriaUnsupportedElements": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fhir2zod",
-    "version": "0.1.0-alpha.7",
+    "version": "0.1.0-alpha.8",
     "publishConfig": {
         "access": "public"
     },

--- a/src/processStructureDefinitionsInOrder.ts
+++ b/src/processStructureDefinitionsInOrder.ts
@@ -119,7 +119,10 @@ export const processStructureDefinitions = (
     }
 
     // Generate an index file that exports all schemas
-    const indexFilePath = path.join(outputDir, 'index.js')
+    const indexFilePath = path.join(
+        outputDir,
+        `index${options.importExtension ? '.js' : '.ts'}`,
+    )
     let indexFileContent = '// Generated index file for FHIR Zod schemas\n\n'
 
     // Use the topological sort ordering for the index file
@@ -161,7 +164,10 @@ export const processStructureDefinitions = (
     console.info('Generated index file for all schemas')
 
     // Generate profileMap.ts file that maps URLs to schemas for constraint profiles
-    const profileMapFilePath = path.join(outputDir, 'profileMap.ts')
+    const profileMapFilePath = path.join(
+        outputDir,
+        `profileMap${options.importExtension ? '.js' : '.ts'}`,
+    )
     let profileMapContent =
         '// Generated profile map for constraint profiles\n\n'
     profileMapContent += 'import { z } from "zod";\n'

--- a/src/types/primitiveTypeSchemaCodes.ts
+++ b/src/types/primitiveTypeSchemaCodes.ts
@@ -39,6 +39,58 @@ export const initializePrimitiveTypeSchemasCodes = (): PrimitiveTypeCodeMap => {
     // Other types
     primitiveTypes.set('boolean', 'z.boolean()')
     primitiveTypes.set('base64Binary', 'z.string()')
+    primitiveTypes.set('xhtml', 'z.string()')
 
     return primitiveTypes
+}
+
+export const getPrimitiveTypeFromUri = (uri: string): string => {
+    // FHIRPath System types
+    if (uri === 'http://hl7.org/fhirpath/System.String') return 'string'
+    if (uri === 'http://hl7.org/fhirpath/System.Boolean') return 'boolean'
+    if (uri === 'http://hl7.org/fhirpath/System.Integer') return 'integer'
+    if (uri === 'http://hl7.org/fhirpath/System.Decimal') return 'decimal'
+    if (uri === 'http://hl7.org/fhirpath/System.Date') return 'date'
+    if (uri === 'http://hl7.org/fhirpath/System.DateTime') return 'dateTime'
+    if (uri === 'http://hl7.org/fhirpath/System.Time') return 'time'
+
+    // Official FHIR StructureDefinition URIs
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/base64Binary')
+        return 'base64Binary'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/boolean')
+        return 'boolean'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/canonical')
+        return 'canonical'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/code') return 'code'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/date') return 'date'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/dateTime')
+        return 'dateTime'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/decimal')
+        return 'decimal'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/id') return 'id'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/instant')
+        return 'instant'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/integer')
+        return 'integer'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/markdown')
+        return 'markdown'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/oid') return 'oid'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/positiveInt')
+        return 'positiveInt'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/string')
+        return 'string'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/time') return 'time'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/unsignedInt')
+        return 'unsignedInt'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/uri') return 'uri'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/url') return 'url'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/uuid') return 'uuid'
+    if (uri === 'http://hl7.org/fhir/StructureDefinition/xhtml') return 'xhtml'
+
+    // Fallback: extract the type name from the URI
+    const parts = uri.split('/')
+    const lastPart = parts[parts.length - 1]
+    const cleanType = lastPart.split('#').pop() || lastPart
+
+    return cleanType.toLowerCase()
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import {
     ElementDefinitionSchemaR4,
     StructureDefinitionSchemaR4,
 } from './types/StructureDefinitions/r4'
+import { getPrimitiveTypeFromUri } from './types/primitiveTypeSchemaCodes'
 type StructureDefinition = z.infer<typeof StructureDefinitionSchemaR4>
 type ElementDefinition = z.infer<typeof ElementDefinitionSchemaR4>
 
@@ -90,7 +91,11 @@ export const parseElementTypes = (
                 }
             }
         }
-        types.push(type.code as string)
+        if (type.code.startsWith('http://hl7.org')) {
+            types.push(getPrimitiveTypeFromUri(type.code))
+        } else {
+            types.push(type.code as string)
+        }
     }
     return types
 }

--- a/test/buildDependencyTree.test.ts
+++ b/test/buildDependencyTree.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadNdjsonFile } from '../src/loader';
-import { writeFileSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { classifyFHIRDefinition, structureDefinitionRule } from '../src/classifier';
+import { join } from 'node:path';
 import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildDependencyMap } from '../src/buildDependencyTree';
+import { classifyFHIRDefinition, structureDefinitionRule } from '../src/classifier';
+import { loadNdjsonFile } from '../src/loader';
 
 describe('buildDependencyMap', () => {
     it('should build dependency map', async () => {
@@ -23,7 +23,9 @@ describe('buildDependencyMap', () => {
         // Define rules for classification
         const rules = {
             structureDefinitions: structureDefinitionRule,
+            // biome-ignore lint/suspicious/noExplicitAny: <explanation>
             valueSets: (obj: any) => obj.resourceType === 'ValueSet',
+            // biome-ignore lint/suspicious/noExplicitAny: <explanation>
             codeSystems: (obj: any) => obj.resourceType === 'CodeSystem'
         };
 
@@ -135,8 +137,8 @@ describe('buildDependencyMap', () => {
         ];
 
         // 配列初期化を確認
-        const dependencyMap = {};
-        dependencyMap['Patient'] = [];
+        const dependencyMap: Record<string, string[]> = {};
+        dependencyMap.Patient = [];
 
         const result = buildDependencyMap(mockStructureDefinitions);
 
@@ -185,8 +187,8 @@ describe('buildDependencyMap', () => {
         ];
 
         // dependencyMapは初期化されたオブジェクト
-        const dependencyMap = {};
-        dependencyMap['Extension'] = 'CodeableConcept';
+        const dependencyMap: Record<string, string[]> = {};
+        dependencyMap.Extension = ['CodeableConcept'];
 
         const result = buildDependencyMap(mockStructureDefinitions);
 

--- a/test/classifier.test.ts
+++ b/test/classifier.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadNdjsonFile } from '../src/loader';
-import { writeFileSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { classifyFHIRDefinition, structureDefinitionRule } from '../src/classifier';
+import { join } from 'node:path';
 import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { classifyFHIRDefinition, structureDefinitionRule } from '../src/classifier';
+import { loadNdjsonFile } from '../src/loader';
 
 describe('classifyFHIRDefinition', () => {
     it('should classify FHIR definitions based on rules', async () => {
@@ -22,7 +22,9 @@ describe('classifyFHIRDefinition', () => {
         // Define rules for classification
         const rules = {
             structureDefinitions: structureDefinitionRule,
+            // biome-ignore lint/suspicious/noExplicitAny: <explanation>
             valueSets: (obj: any) => obj.resourceType === 'ValueSet',
+            // biome-ignore lint/suspicious/noExplicitAny: <explanation>
             codeSystems: (obj: any) => obj.resourceType === 'CodeSystem'
         };
 

--- a/test/constructZodSchemaCode/buildNodeTree.test.ts
+++ b/test/constructZodSchemaCode/buildNodeTree.test.ts
@@ -8,7 +8,8 @@ type ElementDefinition = z.infer<typeof ElementDefinitionSchemaR4>;
 
 describe('buildNodeTree', () => {
     // Helper function to create element definitions with minimal required properties
-    const createElementDefinition = (path: string, type?: any[], min = 0, max = "1"): ElementDefinition => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createElementDefinition = (path: string, type?: any[], min = 0, max = "1"): ElementDefinition => ({
         path,
         min,
         max,

--- a/test/constructZodSchemaCode/buildNodeTree.test.ts
+++ b/test/constructZodSchemaCode/buildNodeTree.test.ts
@@ -541,5 +541,163 @@ describe('buildNodeTree', () => {
                 ]
             });
         });
+        test('nested [x]', () => {
+            const elements = [
+                createElementDefinition('Patient'),
+                createElementDefinition('Patient.value[x]', [
+                    createType('CodeableConcept')
+                ], 0, "1"),
+                createElementDefinition('Patient.value[x].coding', [
+                    createType('Coding')
+                ], 0, "*")
+            ];
+
+            const result = buildNodeTree(elements, 'resource');
+
+            expect(result).toEqual({
+                id: 'Patient',
+                element: elements[0],
+                children: [
+                    {
+                        id: 'Patient.resourceType',
+                        element: {
+                            path: 'Patient.resourceType',
+                            id: 'Patient.resourceType',
+                            type: [{ code: 'string' }],
+                            min: 0,
+                        },
+                        children: []
+                    },
+                    {
+                        id: 'Patient.valueCodeableConcept',
+                        element: expect.objectContaining({
+                            path: 'Patient.valueCodeableConcept',
+                            type: [createType('CodeableConcept')],
+                            min: 0,
+                            max: "1"
+                        }),
+                        children: [
+                            {
+                                id: 'Patient.valueCodeableConcept.coding',
+                                element: expect.objectContaining({
+                                    path: 'Patient.valueCodeableConcept.coding',
+                                    type: [createType('Coding')],
+                                    min: 0,
+                                    max: "*"
+                                }),
+                                children: []
+                            }
+                        ]
+                    }
+                ]
+            });
+        });
+        test('nested [x] with other choice of types elements', () => {
+            const elements = [
+                createElementDefinition('Patient'),
+                createElementDefinition('Patient.value[x]', [
+                    createType('CodeableConcept')
+                ], 0, "1"),
+                createElementDefinition('Patient.value[x].coding', [
+                    createType('Coding')
+                ], 0, "*"),
+                createElementDefinition('Patient.abc', [
+                    createType('CodeableConcept')
+                ], 0, "1"),
+                createElementDefinition('Patient.abc.value[x]', [
+                    createType('CodeableConcept')
+                ], 0, "1"),
+                createElementDefinition('Patient.abc.value[x].coding', [
+                    createType('Coding')
+                ], 0, "*")
+            ];
+
+            const result = buildNodeTree(elements, 'resource');
+
+            expect(result).toEqual({
+                id: 'Patient',
+                element: elements[0],
+                children: [
+                    {
+                        id: 'Patient.resourceType',
+                        element: {
+                            path: 'Patient.resourceType',
+                            id: 'Patient.resourceType',
+                            type: [{ code: 'string' }],
+                            min: 0,
+                        },
+                        children: []
+                    },
+                    {
+                        id: 'Patient.valueCodeableConcept',
+                        element: expect.objectContaining({
+                            path: 'Patient.valueCodeableConcept',
+                            type: [createType('CodeableConcept')],
+                            min: 0,
+                            max: "1"
+                        }),
+                        children: [
+                            {
+                                id: 'Patient.valueCodeableConcept.coding',
+                                element: expect.objectContaining({
+                                    path: 'Patient.valueCodeableConcept.coding',
+                                    type: [createType('Coding')],
+                                    min: 0,
+                                    max: "*"
+                                }),
+                                children: []
+                            }
+                        ]
+                    },
+                    {
+                        id: 'Patient.abc',
+                        element: expect.objectContaining({
+                            id: 'Patient.abc',
+                            path: 'Patient.abc',
+                            type: [createType('CodeableConcept')],
+                            max: "1",
+                            min: 0,
+                        }),
+                        children: [
+                            {
+                                id: 'Patient.abc.valueCodeableConcept',
+                                element: expect.objectContaining({
+                                    path: 'Patient.abc.valueCodeableConcept',
+                                    type: [createType('CodeableConcept')],
+                                    min: 0,
+                                    max: "1"
+                                }),
+                                children: [
+                                    {
+                                        id: 'Patient.abc.valueCodeableConcept.coding',
+                                        element: expect.objectContaining({
+                                            path: 'Patient.abc.valueCodeableConcept.coding',
+                                            type: [createType('Coding')],
+                                            min: 0,
+                                            max: "*"
+                                        }),
+                                        children: []
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            });
+        });
+        test('nested [x] with multiple types should throw an error', () => {
+            const elements = [
+                createElementDefinition('Patient'),
+                createElementDefinition('Patient.value[x]', [
+                    createType('CodeableConcept'),
+                    createType('string'),
+                ], 0, "1"),
+                createElementDefinition('Patient.value[x].coding', [
+                    createType('Coding'),
+                ], 0, "*"),
+            ];
+
+            expect(() => buildNodeTree(elements, 'resource')).toThrow('path Patient.value[x].coding has multiple type definitions of basePath: Patient.value');
+        });
     });
 });

--- a/test/constructZodSchemaCode/constructImportStatements.test.ts
+++ b/test/constructZodSchemaCode/constructImportStatements.test.ts
@@ -15,7 +15,8 @@ describe('constructImportStatements', () => {
     } as ElementDefinition);
 
     // Helper function to create a type object
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
         code,
         extension
     } as ElementDefinition['type'][0]);

--- a/test/constructZodSchemaCode/constructZodOnChoiceOfType.test.ts
+++ b/test/constructZodSchemaCode/constructZodOnChoiceOfType.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
 import { testModules } from '../../src/constructZodSchemaCode';
 import { ElementDefinitionSchemaR4 } from '../../src/types/StructureDefinitions/r4';
-import { z } from 'zod';
-import { describe, expect, test } from 'vitest';
 import { PrimitiveTypeCodeMap } from '../../src/types/primitiveTypeSchemaCodes';
 
 const { constructZodOnChoiceOfType } = testModules;
@@ -15,7 +15,8 @@ describe('constructZodOnChoiceOfType', () => {
     } as ElementDefinition);
 
     // Helper function to create a type object
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
         code,
         extension
     } as ElementDefinition['type'][0]);

--- a/test/constructZodSchemaCode/constructZodSchemaCode.test.ts
+++ b/test/constructZodSchemaCode/constructZodSchemaCode.test.ts
@@ -19,7 +19,7 @@ describe('constructZodSchemaCode', () => {
         name: options.name || 'TestResource',
         status: options.status || 'active',
         kind: options.kind || 'resource',
-        abstract: options.abstract || false,
+        abstract: options.abstract,
         type: options.type || 'TestResource',
         baseDefinition: options.baseDefinition || 'http://hl7.org/fhir/StructureDefinition/DomainResource',
         derivation: options.derivation || 'specialization',

--- a/test/constructZodSchemaCode/constructZodSchemaCode.test.ts
+++ b/test/constructZodSchemaCode/constructZodSchemaCode.test.ts
@@ -38,7 +38,8 @@ describe('constructZodSchemaCode', () => {
     } as ElementDefinition);
 
     // Helper to create a type
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
         code,
         extension
     } as ElementDefinition['type'][0]);

--- a/test/constructZodSchemaCode/constructZodSchemaCodeFromNodeTree.cardinality.test.ts
+++ b/test/constructZodSchemaCode/constructZodSchemaCodeFromNodeTree.cardinality.test.ts
@@ -9,7 +9,8 @@ type ElementDefinition = z.infer<typeof ElementDefinitionSchemaR4>;
 
 describe('constructZodSchemaCodeFromNodeTree - Cardinality Tests', () => {
     // Helper to create an element definition
-    const createElement = (path: string, type?: any[], min = 0, max = "1"): ElementDefinition => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createElement = (path: string, type?: any[], min = 0, max = "1"): ElementDefinition => ({
         path,
         type,
         min,
@@ -17,13 +18,15 @@ describe('constructZodSchemaCodeFromNodeTree - Cardinality Tests', () => {
     } as ElementDefinition);
 
     // Helper to create a type
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
         code,
         extension
     } as ElementDefinition['type'][0]);
 
     // Helper to create a node
-    const createNode = (id: string, element: ElementDefinition, children: any[] = []): any => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createNode = (id: string, element: ElementDefinition, children: any[] = []): any => ({
         id,
         element,
         children

--- a/test/constructZodSchemaCode/constructZodSchemaCodeFromNodeTree.choice.test.ts
+++ b/test/constructZodSchemaCode/constructZodSchemaCodeFromNodeTree.choice.test.ts
@@ -9,7 +9,8 @@ type ElementDefinition = z.infer<typeof ElementDefinitionSchemaR4>;
 
 describe('constructZodSchemaCodeFromNodeTree - Choice Type Tests', () => {
     // Helper to create an element definition
-    const createElement = (path: string, type?: any[], min = 0, max = "1"): ElementDefinition => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createElement = (path: string, type?: any[], min = 0, max = "1"): ElementDefinition => ({
         path,
         type,
         min,
@@ -17,13 +18,15 @@ describe('constructZodSchemaCodeFromNodeTree - Choice Type Tests', () => {
     } as ElementDefinition);
 
     // Helper to create a type
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
         code,
         extension
     } as ElementDefinition['type'][0]);
 
     // Helper to create a node
-    const createNode = (id: string, element: ElementDefinition, children: any[] = []): any => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createNode = (id: string, element: ElementDefinition, children: any[] = []): any => ({
         id,
         element,
         children

--- a/test/constructZodSchemaCode/constructZodSchemaCodeFromNodeTree.reference.test.ts
+++ b/test/constructZodSchemaCode/constructZodSchemaCodeFromNodeTree.reference.test.ts
@@ -18,13 +18,15 @@ describe('constructZodSchemaCodeFromNodeTree - Reference Tests', () => {
     } as ElementDefinition);
 
     // Helper to create a type
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
         code,
         extension
     } as ElementDefinition['type'][0]);
 
     // Helper to create a node
-    const createNode = (id: string, element: ElementDefinition, children: any[] = []): any => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createNode = (id: string, element: ElementDefinition, children: any[] = []): any => ({
         id,
         element,
         children

--- a/test/constructZodSchemaCode/constructZodSchemaCodeFromNodeTree.test.ts
+++ b/test/constructZodSchemaCode/constructZodSchemaCodeFromNodeTree.test.ts
@@ -9,7 +9,8 @@ type ElementDefinition = z.infer<typeof ElementDefinitionSchemaR4>;
 
 describe('constructZodSchemaCodeFromNodeTree - Basic Tests', () => {
     // Helper to create an element definition
-    const createElement = (path: string, type?: any[], min = 0, max = "1"): ElementDefinition => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createElement = (path: string, type?: any[], min = 0, max = "1"): ElementDefinition => ({
         path,
         type,
         min,
@@ -17,13 +18,15 @@ describe('constructZodSchemaCodeFromNodeTree - Basic Tests', () => {
     } as ElementDefinition);
 
     // Helper to create a type
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
         code,
         extension
     } as ElementDefinition['type'][0]);
 
     // Helper to create a node
-    const createNode = (id: string, element: ElementDefinition, children: any[] = []): any => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createNode = (id: string, element: ElementDefinition, children: any[] = []): any => ({
         id,
         element,
         children

--- a/test/constructZodSchemaCode/parseElementTypes.test.ts
+++ b/test/constructZodSchemaCode/parseElementTypes.test.ts
@@ -8,7 +8,8 @@ type ElementDefinition = z.infer<typeof ElementDefinitionSchemaR4>;
 
 describe('parseElementTypes', () => {
     // Helper function to create a type object
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
         code,
         extension
     } as ElementDefinition['type'][0]);

--- a/test/constructZodSchemaCode/parseElementTypes.test.ts
+++ b/test/constructZodSchemaCode/parseElementTypes.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
 import { testModules } from '../../src/constructZodSchemaCode';
 import { ElementDefinitionSchemaR4 } from '../../src/types/StructureDefinitions/r4';
-import { z } from 'zod';
-import { describe, expect, test } from 'vitest';
 
 const { parseElementTypes } = testModules;
 type ElementDefinition = z.infer<typeof ElementDefinitionSchemaR4>;
@@ -105,5 +105,14 @@ describe('parseElementTypes', () => {
         const result = parseElementTypes(types);
 
         expect(result).toEqual(['Resource', 'string']);
+    });
+    test('should handle primitive types that do not include a FHIR type extension', () => {
+        const types = [
+            createType('http://hl7.org/fhirpath/System.String')
+        ];
+
+        const result = parseElementTypes(types);
+
+        expect(result).toEqual(['string']);
     });
 });

--- a/test/generateAndLint.test.ts
+++ b/test/generateAndLint.test.ts
@@ -9,4 +9,6 @@ describe('generateAndLint', () => {
         expect(output.status).toBe(0)
 
     });
+}, {
+    timeout: 10000,
 });

--- a/test/generateAndLint.test.ts
+++ b/test/generateAndLint.test.ts
@@ -1,0 +1,12 @@
+import { spawnSync } from 'node:child_process';
+import { describe, expect, test } from 'vitest';
+describe('generateAndLint', () => {
+    test('should generate and pass lint a zod schema', () => {
+        spawnSync('npx',['tsx', 'src/index.ts', '-f', 'examples/hl7.fhir.r4.core@4.0.1/hl7.fhir.r4.core-4.0.1.ndjson', '-f', 'examples/jp.core.r4/jp-core.r4-1.1.1-rc.ndjson', '-o', 'test/tmp', '2> /dev/null'])
+        const output = spawnSync('npx',['biome', 'lint', 'test/tmp'])
+        spawnSync('rm',['-rf', 'test/tmp'])
+        
+        expect(output.status).toBe(0)
+
+    });
+});

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadNdjsonFile } from '../src/loader';
-import { writeFileSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadNdjsonFile } from '../src/loader';
 
 describe('loadNdjsonFile', () => {
     const testDir = tmpdir();
@@ -28,13 +28,14 @@ describe('loadNdjsonFile', () => {
         // Clean up test file
         try {
             unlinkSync(testFilePath);
-        } catch (error) {
+        } catch (_error) {
             // Ignore if file doesn't exist
         }
     });
 
     it('should load and parse an NDJSON file correctly', async () => {
         const stream = loadNdjsonFile(testFilePath);
+        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
         const results: any[] = [];
 
         // Collect data from the stream
@@ -57,6 +58,7 @@ describe('loadNdjsonFile', () => {
         writeFileSync(testFilePath, ndjsonWithEmptyLines, 'utf8');
 
         const stream = loadNdjsonFile(testFilePath);
+        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
         const results: any[] = [];
 
         // Collect data from the stream
@@ -108,6 +110,7 @@ describe('loadNdjsonFile', () => {
 
         try {
             const stream = loadNdjsonFile(relativeTestPath);
+            // biome-ignore lint/suspicious/noExplicitAny: <explanation>
             const results: any[] = [];
 
             // Collect data from the stream
@@ -122,7 +125,7 @@ describe('loadNdjsonFile', () => {
             // Clean up
             try {
                 unlinkSync(absoluteTestPath);
-            } catch (error) {
+            } catch (_error) {
                 // Ignore if file doesn't exist
             }
         }

--- a/test/merger/buildHasChildren.test.ts
+++ b/test/merger/buildHasChildren.test.ts
@@ -113,6 +113,7 @@ describe('buildHasChildren', () => {
     })
 
     it('should handle empty input', () => {
+        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
         const elements: any[] = []
         const result = buildHasChildren(elements)
         expect(result).toBeDefined()

--- a/test/merger/expandTree.test.ts
+++ b/test/merger/expandTree.test.ts
@@ -1,28 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { z } from 'zod'
 import { testModules } from '../../src/merger'
-import { ElementDefinitionSchemaR4 } from '../../src/types/StructureDefinitions/r4'
 
 const { expandTree, buildTree, buildHasChildren, buildElementMap } = testModules
-type ElementDefinition = z.infer<typeof ElementDefinitionSchemaR4>
 
 describe('ExpandTree', () => {
-    const createType = (code: string, extension?: any[]): ElementDefinition['type'][0] => ({
-        code,
-        extension
-    } as ElementDefinition['type'][0]);
-
-    // Helper function to create an extension for FHIR type
-    const createFhirTypeExtension = (valueUrl: string) => ({
-        url: "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-        valueUrl
-    });
-
-    // Helper function to create a non-FHIR extension
-    const createOtherExtension = (url: string, valueString: string) => ({
-        url,
-        valueString
-    });
 
     // テスト用のモックデータ
     const createElementDefinition = (path: string, min = 0, max = "1", type = [{ code: 'Element' }]) => ({
@@ -42,6 +23,7 @@ describe('ExpandTree', () => {
         ]
     })
 
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     const createStructureDefinition = (id: string, type: string, elements: any[]) => ({
         resourceType: 'StructureDefinition' as const,
         id,

--- a/test/merger/replaceNodeByPath.test.ts
+++ b/test/merger/replaceNodeByPath.test.ts
@@ -84,7 +84,6 @@ describe('replaceNodeByPath', () => {
         }
         const result = replaceNodeByPath(mockNode, 'root.child1', newNode)
         expect(result).not.toBeNull()
-        const child1 = result?.children.get('root.child1')
     })
 
     it('should return a deep copy of the tree', () => {


### PR DESCRIPTION
- Fixed xhtml file structure due to the lack of extensions at element.type
- in-middle choice of types like `SomeResource.value[x].coding` to properly convert concrete type